### PR TITLE
Release v0.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is part of [Membrane Multimedia Framework](https://membraneframework.org).
 Add the following line to your `deps` in `mix.exs`.  Run `mix deps.get`.
 
 ```elixir
-  {:membrane_hackney_plugin, "~> 0.8.1"}
+  {:membrane_hackney_plugin, "~> 0.8.2"}
 ```
 
 ## Sample usage

--- a/lib/membrane_hackney/source.ex
+++ b/lib/membrane_hackney/source.ex
@@ -14,7 +14,7 @@ defmodule Membrane.Hackney.Source do
 
   require Membrane.Logger
 
-  def_output_pad :output, caps: {RemoteStream, type: :packetized, content_format: nil}
+  def_output_pad :output, caps: {RemoteStream, type: :bytestream, content_format: nil}
 
   def_options location: [
                 type: :string,
@@ -98,7 +98,7 @@ defmodule Membrane.Hackney.Source do
   def handle_prepared_to_playing(_ctx, state) do
     case connect(state) do
       {:ok, state} ->
-        caps = [caps: {:output, %RemoteStream{type: :packetized}}]
+        caps = [caps: {:output, %RemoteStream{type: :bytestream}}]
         {{:ok, caps}, state}
 
       error ->

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.Hackney.Plugin.Mixfile do
   use Mix.Project
 
-  @version "0.8.1"
+  @version "0.8.2"
   @github_url "http://github.com/membraneframework/membrane_hackney_plugin"
 
   def project do

--- a/test/membrane_hackney/source_test.exs
+++ b/test/membrane_hackney/source_test.exs
@@ -66,7 +66,7 @@ defmodule Membrane.Hackney.SourceTest do
         body: "body"
       })
 
-    caps = [caps: {:output, %RemoteStream{type: :packetized}}]
+    caps = [caps: {:output, %RemoteStream{type: :bytestream}}]
     assert {{:ok, ^caps}, new_state} = @module.handle_prepared_to_playing(nil, state)
     assert new_state.async_response == :mock_response
     assert new_state.streaming == true


### PR DESCRIPTION
Repair source's caps description - caps on output are now `%Membrane.RemoteStream{type: :byte stream}`